### PR TITLE
Replcaing usages of apache commons-lang with commons-lang3

### DIFF
--- a/alien4cloud-http-repository-plugin/src/main/java/alien4cloud/repository/http/ConfigurableHttpArtifactResolver.java
+++ b/alien4cloud-http-repository-plugin/src/main/java/alien4cloud/repository/http/ConfigurableHttpArtifactResolver.java
@@ -5,7 +5,7 @@ import static alien4cloud.repository.http.HttpUtil.isHttpURL;
 import java.util.Map;
 
 import jakarta.annotation.Resource;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import alien4cloud.component.repository.IConfigurableArtifactResolver;
 import alien4cloud.component.repository.exception.InvalidResolverConfigurationException;

--- a/alien4cloud-http-repository-plugin/src/main/java/alien4cloud/repository/http/HttpArtifactResolver.java
+++ b/alien4cloud-http-repository-plugin/src/main/java/alien4cloud/repository/http/HttpArtifactResolver.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;

--- a/alien4cloud-repository-plugin-common/src/main/java/alien4cloud/repository/util/ResolverUtil.java
+++ b/alien4cloud-repository-plugin-common/src/main/java/alien4cloud/repository/util/ResolverUtil.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import alien4cloud.component.repository.IArtifactResolver;
 import alien4cloud.component.repository.IConfigurableArtifactResolver;


### PR DESCRIPTION
* parent project has migrated to `commons-lang3` and old version is no longer available at the runtime;